### PR TITLE
new version of snabbdom use ES6 modules so we need to add .default

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = function(content) {
 
     var query = loaderUtils.parseQuery(this.query);
     var key = 'svg-' + path.basename(this.resourcePath).slice(0, -4);
-    var text = '\n\'use strict\';\n' + 'var h = require(\'snabbdom/h\');\n';
+    var text = '\n\'use strict\';\n' + 'var h = require(\'snabbdom/h\').default;\n';
     var opts = {omitFill: query.omitFill};
 
     if (!query.omitKey) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svg-snabbdom-loader",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Webpack svg-files to snabbdom vdom loader",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
New version of snabbdom use ES6 modules so we need to add .default to `require`s.
Also as this will break the old APIs I have upgraded the version in `package.json` to `1.0.0` indicating this breaking change.